### PR TITLE
host helm chart via github pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          # Upload entire repository
+          path: './pages'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      release-upload-url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: release
+        uses: actions/create-release@v1
+        id: create_release
+        with:
+          draft: false
+          prerelease: false
+          release_name: ${{ github.ref }}
+          tag_name: ${{ github.ref }}
+          # body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  package-and-publish-helm-chart:
+    needs: release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: install helm
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: package helm chart
+        run: helm package --dependency-update ./chart
+
+      - name: install yq
+        run: |
+          VERSION=v4.34.1
+          BINARY=yq_linux_amd64
+          curl -Lo yq https://github.com/mikefarah/yq/releases/download/$VERSION/$BINARY && chmod +x yq
+
+      - name: get helm chart name and version
+        run: |
+          CHART_NAME=$(helm show chart ./chart | ./yq .name)
+          CHART_VERSION=$(helm show chart ./chart | ./yq .version)
+          echo "CHART_NAME=$CHART_NAME" >> $GITHUB_ENV
+          echo "CHART_VERSION=$CHART_VERSION" >> $GITHUB_ENV
+
+      - name: upload chart to release artifacts
+        uses: actions/upload-release-asset@v1
+        id: upload-chart
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ needs.release.outputs.release-upload-url }}
+          asset_path: ./${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
+          asset_name: ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
+          asset_content_type: application/x-tar
+
+      - name: generate helm index
+        run: helm repo index . --url $DOWNLOAD_URL --merge pages/index.yaml
+        env:
+          DOWNLOAD_URL: ${{ steps.upload-chart.outputs.browser_download_url }}
+
+      - name: commit to temporary branch
+        run: |
+          INDEX=pages/index.yaml
+          HASH=$(sudo cat /dev/random | tr -dc 'a-zA-Z0-9~!@#$%^&*_-'  | head -c 7)
+          echo "HASH=$HASH" >> $GITHUB_ENV
+          git checkout -b helm_index_update_"$HASH"
+          git add $INDEX && git commit $INDEX -m "Updating index.yaml for new release"
+
+      - name: create pull request
+        run: gh pr create -B main -H helm_index_update_"$HASH" --title 'Merge helm_index_update into main' --body 'Created by Github release action'
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: package helm chart
-        run: helm package --dependency-update ./chart
+        run: |
+          helm package -u ./chart -d pages/
 
       - name: install yq
         run: |
@@ -70,24 +71,31 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.release.outputs.release-upload-url }}
-          asset_path: ./${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
+          asset_path: ./pages/${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
           asset_name: ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
           asset_content_type: application/x-tar
 
       - name: generate helm index
-        run: helm repo index . --url $DOWNLOAD_URL --merge pages/index.yaml
+        run: |
+          cd pages
+          helm repo index . --url $DOWNLOAD_URL --merge index.yaml
         env:
           DOWNLOAD_URL: ${{ steps.upload-chart.outputs.browser_download_url }}
 
       - name: commit to temporary branch
         run: |
           INDEX=pages/index.yaml
-          HASH=$(sudo cat /dev/random | tr -dc 'a-zA-Z0-9~!@#$%^&*_-'  | head -c 7)
+          HASH=$(echo "$GITHUB_SHA" | head -c 5)
           echo "HASH=$HASH" >> $GITHUB_ENV
-          git checkout -b helm_index_update_"$HASH"
+          git config --global user.email "github@action.com"                                                                                                                                                       │
+          git config --global user.name "Release Action"
+          git checkout -b helm-index-update-"$HASH"
           git add $INDEX && git commit $INDEX -m "Updating index.yaml for new release"
+          git push origin helm_index_update_"$HASH"
+        env:
+          GITHUB_SHA: ${{ github.sha }}
 
       - name: create pull request
-        run: gh pr create -B main -H helm_index_update_"$HASH" --title 'Merge helm_index_update into main' --body 'Created by Github release action'
+        run: gh pr create -B main -H helm-index-update-"$HASH" --title 'Merge helm_index_update into main' --body 'Created by Github release action'
         env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,8 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    outputs:
+      browser_download_url: ${{ steps.upload-chart.outputs.browser_download_url }}
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -49,7 +51,7 @@ jobs:
 
       - name: package helm chart
         run: |
-          helm package -u ./chart -d pages/
+          helm package -u ./chart
 
       - name: install yq
         run: |
@@ -71,31 +73,47 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ needs.release.outputs.release-upload-url }}
-          asset_path: ./pages/${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
+          asset_path: ./${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
           asset_name: ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz
           asset_content_type: application/x-tar
 
+  pr-for-helm-index-update:
+    needs: package-and-publish-helm-chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: main
       - name: generate helm index
         run: |
-          cd pages
+          GH_PAGES_FOLDER=pages
+          echo "GH_PAGES_FOLDER=$GH_PAGES_FOLDER" >> $GITHUB_ENV
+          cd $GH_PAGES_FOLDER
+          curl -LO "$DOWNLOAD_URL"
           helm repo index . --url $DOWNLOAD_URL --merge index.yaml
+          cd $(git rev-parse --show-toplevel)
         env:
-          DOWNLOAD_URL: ${{ steps.upload-chart.outputs.browser_download_url }}
+          DOWNLOAD_URL: ${{ needs.package-and-publish-helm-chart.outputs.browser_download_url }}
 
       - name: commit to temporary branch
         run: |
-          INDEX=pages/index.yaml
+          INDEX=$GH_PAGES_FOLDER/index.yaml
           HASH=$(echo "$GITHUB_SHA" | head -c 5)
-          echo "HASH=$HASH" >> $GITHUB_ENV
+          BRANCH_NAME=helm-index-update-"$HASH"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
           git config --global user.email "github@action.com"                                                                                                                                                       │
           git config --global user.name "Release Action"
-          git checkout -b helm-index-update-"$HASH"
-          git add $INDEX && git commit $INDEX -m "Updating index.yaml for new release"
-          git push origin helm_index_update_"$HASH"
+          git checkout -b "$BRANCH_NAME"
+          git add "$INDEX" && git commit $INDEX -m "Updating index.yaml for new release"
+          git push origin "$BRANCH_NAME"
         env:
           GITHUB_SHA: ${{ github.sha }}
 
       - name: create pull request
-        run: gh pr create -B main -H helm-index-update-"$HASH" --title 'Merge helm_index_update into main' --body 'Created by Github release action'
+        run: gh pr create -B throwaway -H "$BRANCH_NAME" --title "Merge $BRANCH_NAME into main" --body 'Created by Github release action'
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -123,9 +123,20 @@ Available Variables:
 
 ## Helm
 
+Add public source:
+```bash
+helm repo add releasebot https://rancher-government-carbide.github.io/releasebot
+helm repo update
+```
+
+Install:
 ```bash
 export HELM_RELEASE_NAME=releasebot
 export VALUES_FILE=values.yaml
+# from public release
+helm install $HELM_RELEASE_NAME releasebot/releasebot --values $VALUES_FILE
+# OR
+# with locally cloned repo
 helm install $HELM_RELEASE_NAME ./chart --values $VALUES_FILE
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ Available Variables:
 | $AUTHOR.AVATARURL      | Url for viewing the Github avatar image of the release author
 | $AUTHOR.HTMLURL        | Url for viewing the Github account of the release author
 
+## Helm
+
+```bash
+export HELM_RELEASE_NAME=releasebot
+export VALUES_FILE=values.yaml
+helm install $HELM_RELEASE_NAME ./chart --values $VALUES_FILE
+```
+
 ## Development
 
 #### Build

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+    <title>Releasebot Helm Chart</title>
+
+    <style>
+      body {
+        font-family: Arial, Geneva, Helvetica, sans-serif;
+      }
+    </style>
+  </head>
+
+  <body>
+
+    <h1 id="releasebot-header">Releasebot Helm Chart</h1>
+    <h2 id="usage">How To Use (Internet)</h2>
+
+    <code>
+    $ helm repo add releasebot https://rancher-government-carbide.github.io/releasebot<br />
+    $ helm repo update<br />
+    $ helm search repo releasebot<br />
+    $ helm install example-release releasebot/releasebot
+    </code>
+
+    <h2 id="airgap">How to Use (Airgap)</h2>
+    <h3>On Connected Device</h3>
+    <code>
+    $ helm repo add releasebot https://rancher-government-carbide.github.io/releasebot<br />
+    $ helm repo update<br />
+    $ helm search repo releasebot<br />
+    $ helm pull releasebot/releasebot
+    </code>
+
+    <p>
+    Take the resulting <code>tgz</code> file over the airgap.
+    </p>
+    
+
+    <h3>On Airgapped Device</h3>
+    <code>
+      $ helm install example-release releasebot-x.y.z.tgz<chart>
+    </code>
+  </body>
+</html>


### PR DESCRIPTION
- chore(readme): helm installation instructions
- added "temporary" html file for gh pages chart hosting
- chore(github-action): release action (publishes helm chart too)
- fix(github-action): add git config, proper gh-pages dir, gh-token var
- refactor(gh-action): break helm index update PR into separate job
- chore(gh-action): publish helm chart via custom action
- chore(README): updated helm installation instructions
